### PR TITLE
Remove unneeded entry option for organ permeability of itraconazole

### DIFF
--- a/Itraconazole-Model.json
+++ b/Itraconazole-Model.json
@@ -4754,23 +4754,6 @@
           ]
         }
       ],
-      "Permeability": [
-        {
-          "Name": "Fit",
-          "IsDefault": false,
-          "Parameters": [
-            {
-              "Name": "Permeability",
-              "Value": 0.1111202419,
-              "Unit": "cm/min",
-              "ValueOrigin": {
-                "Source": "ParameterIdentification",
-                "Description": "Fit"
-              }
-            }
-          ]
-        }
-      ],
       "PkaTypes": [
         {
           "Type": "Base",


### PR DESCRIPTION
This option is a remnant from tries during model building.
Fixes #8 